### PR TITLE
Refactor weakness initialization in Agent classes

### DIFF
--- a/Agent/Agent.cs
+++ b/Agent/Agent.cs
@@ -23,27 +23,6 @@ namespace Investigation_Game
             RndOfWeakness = new string[weaknesses.Length];
             RndOfWeakness = weaknesses;
         }
-        public void GetNumOfWeaknesses()
-        {
-            switch (Name)
-            {
-                case "JuniorAgent":
-                    NumOfWeaknesses = 2;
-                    break;
-                case "SeniorAgent":
-                    NumOfWeaknesses = 4;
-                    break;
-                case "SquadLeader":
-                    NumOfWeaknesses = 6;
-                    break;
-                case "CompanyCommander":
-                    NumOfWeaknesses = 8;
-                    break;
-                default:
-                    NumOfWeaknesses = 2;
-                    break;
-            }
-        }
         public void GetRandomWeakness()
         {
             Random rnd = new Random();

--- a/Agent/CompanyCommander.cs
+++ b/Agent/CompanyCommander.cs
@@ -11,7 +11,7 @@ namespace Investigation_Game
         public CompanyCommander(string[] weaknesses) : base(weaknesses)
         {
             Name = "CompanyCommander";
-            GetNumOfWeaknesses();
+            NumOfWeaknesses = 8;
             GetRandomWeakness();
             ArrToDictionary();
         }

--- a/Agent/JuniorAgent.cs
+++ b/Agent/JuniorAgent.cs
@@ -11,7 +11,7 @@ namespace Investigation_Game
         public JuniorAgent(string[] weaknesses) : base(weaknesses)
         {
             Name = "JuniorAgent";
-            GetNumOfWeaknesses();
+            NumOfWeaknesses = 2;
             GetRandomWeakness();
             ArrToDictionary();
         }

--- a/Agent/SeniorAgent.cs
+++ b/Agent/SeniorAgent.cs
@@ -11,7 +11,7 @@ namespace Investigation_Game
         public SeniorAgent(string[] weaknesses) : base(weaknesses)
         {
             Name = "SeniorAgent";
-            GetNumOfWeaknesses();
+            NumOfWeaknesses = 4;
             GetRandomWeakness();
             ArrToDictionary();
         }

--- a/Agent/SquadLeader.cs
+++ b/Agent/SquadLeader.cs
@@ -11,7 +11,7 @@ namespace Investigation_Game
         public SquadLeader(string[] weaknesses) : base(weaknesses)
         {
             Name = "SquadLeader";
-            GetNumOfWeaknesses();
+            NumOfWeaknesses = 6;
             GetRandomWeakness();
             ArrToDictionary();
         }


### PR DESCRIPTION
Removed the `GetNumOfWeaknesses` method from the `Agent` class. Weakness counts are now directly assigned in the constructors of `CompanyCommander`, `JuniorAgent`, `SeniorAgent`, and `SquadLeader`, simplifying the initialization process.