### PR TITLE
Fix rank display and set ranks for agents

### DIFF
--- a/Agent/CompanyCommander.cs
+++ b/Agent/CompanyCommander.cs
@@ -11,6 +11,7 @@ namespace Investigation_Game
         public CompanyCommander(string[] weaknesses) : base(weaknesses)
         {
             Name = "CompanyCommander";
+            Rank = "Company Commander";
             NumOfWeaknesses = 8;
             GetRandomWeakness();
             ArrToDictionary();

--- a/Agent/JuniorAgent.cs
+++ b/Agent/JuniorAgent.cs
@@ -11,6 +11,7 @@ namespace Investigation_Game
         public JuniorAgent(string[] weaknesses) : base(weaknesses)
         {
             Name = "JuniorAgent";
+            Rank = "Junior";
             NumOfWeaknesses = 2;
             GetRandomWeakness();
             ArrToDictionary();

--- a/Agent/SeniorAgent.cs
+++ b/Agent/SeniorAgent.cs
@@ -11,6 +11,7 @@ namespace Investigation_Game
         public SeniorAgent(string[] weaknesses) : base(weaknesses)
         {
             Name = "SeniorAgent";
+            Rank = "Senior";
             NumOfWeaknesses = 4;
             GetRandomWeakness();
             ArrToDictionary();

--- a/Agent/SquadLeader.cs
+++ b/Agent/SquadLeader.cs
@@ -11,6 +11,7 @@ namespace Investigation_Game
         public SquadLeader(string[] weaknesses) : base(weaknesses)
         {
             Name = "SquadLeader";
+            Rank = "Squad Leader";
             NumOfWeaknesses = 6;
             GetRandomWeakness();
             ArrToDictionary();

--- a/InvestigationManager.cs
+++ b/InvestigationManager.cs
@@ -57,7 +57,7 @@ namespace Investigation_Game
             Console.WriteLine("┌──────────────────────────────────────────────────────────");
             Console.WriteLine($"│                Agent Details: {agent.Name,-20}           ");
             Console.WriteLine("├──────────────────────────────────────────────────────────");
-            Console.WriteLine($"│ Rank: {agent.Name,-30}                                  ");
+            Console.WriteLine($"│ Rank: {agent.Rank,-30}                                  ");
             Console.WriteLine($"│ Number of weaknesses: {agent.NumOfWeaknesses,-10}                ");
 
             //מאפשר לראות את החולשות שהוגרלו באופן רנדומלי


### PR DESCRIPTION
## Summary
- show the agent's rank correctly in InvestigationManager
- initialize `Rank` for each agent class

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547dc07fb8832483d8646a702bb583